### PR TITLE
Don't clear isCommitStateDirty flag in setReadOnly

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
@@ -409,7 +409,6 @@ public abstract class ProxyConnection implements Connection
    {
       delegate.setReadOnly(readOnly);
       isReadOnly = readOnly;
-      isCommitStateDirty = false;
       dirtyBits |= DIRTY_BIT_READONLY;
    }
 

--- a/src/test/java/com/zaxxer/hikari/pool/ConnectionStateTest.java
+++ b/src/test/java/com/zaxxer/hikari/pool/ConnectionStateTest.java
@@ -164,6 +164,9 @@ public class ConnectionStateTest
 
             resultSet.updateRow();
             assertTrue(TestElf.getConnectionCommitDirtyState(connection));
+
+            connection.setReadOnly(!connection.isReadOnly());
+            assertTrue(TestElf.getConnectionCommitDirtyState(connection));
          }
       }
    }


### PR DESCRIPTION
When autoCommit is false, if `setReadOnly` is called on a connection after executing some queries, closing the connection returns the dirty connection (with transaction open) to the pool.

```java
HikariDataSource ds = /* setup the pool */;
ds.setAutoCommit(false);
try (Connection conn = ds.getConnection()) {
  // ... execute some queries on `conn`
  conn.setReadOnly(false);
}
// connection returned to the pool with transaction open
```

In the above scenario, the following cleanup logic is not executed.

https://github.com/dittos/HikariCP/blob/ed2da5f1f4ef19f871fac12effc0b199706905dc/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java#L248-L251

Anyway I don't see why `isCommitStateDirty` should be set to false when `setReadOnly` is called. The line was added in 6ed3b185912bd835fb1a25da6ba80e0226fb7f2e without useful description.